### PR TITLE
feat: Implement road network data models and schemas

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from app.config import settings
 from app.db.database import Base
+from app.models import EdgeModel, NodeModel  # noqa: F401 - Import models to register metadata
 
 config = context.config
 

--- a/alembic/versions/001_create_road_network_tables.py
+++ b/alembic/versions/001_create_road_network_tables.py
@@ -1,0 +1,147 @@
+"""Create road network tables (dt_nodes and dt_edges)
+
+Revision ID: 001_road_network
+Revises:
+Create Date: 2024-01-18
+
+"""
+
+from typing import Sequence, Union
+
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "001_road_network"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create dt_nodes table (prefixed to avoid conflicts with PostGIS Tiger tables)
+    op.create_table(
+        "dt_nodes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("node_type", sa.String(length=50), nullable=False),
+        sa.Column(
+            "position",
+            geoalchemy2.types.Geometry(
+                geometry_type="POINT",
+                srid=4326,
+                from_text="ST_GeomFromEWKT",
+                name="geometry",
+            ),
+            nullable=False,
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("metadata_json", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Create indexes for dt_nodes table
+    op.create_index(
+        "idx_dt_nodes_position_gist",
+        "dt_nodes",
+        ["position"],
+        unique=False,
+        postgresql_using="gist",
+    )
+    op.create_index("idx_dt_nodes_node_type", "dt_nodes", ["node_type"], unique=False)
+    op.create_index("idx_dt_nodes_is_active", "dt_nodes", ["is_active"], unique=False)
+
+    # Create dt_edges table (prefixed to avoid conflicts with PostGIS Tiger tables)
+    op.create_table(
+        "dt_edges",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("start_node_id", sa.Integer(), nullable=False),
+        sa.Column("end_node_id", sa.Integer(), nullable=False),
+        sa.Column("road_type", sa.String(length=50), nullable=False),
+        sa.Column(
+            "geometry",
+            geoalchemy2.types.Geometry(
+                geometry_type="LINESTRING",
+                srid=4326,
+                from_text="ST_GeomFromEWKT",
+                name="geometry",
+            ),
+            nullable=False,
+        ),
+        sa.Column("length", sa.Float(), nullable=False),
+        sa.Column("max_speed", sa.Integer(), nullable=False),
+        sa.Column("lanes", sa.Integer(), nullable=False),
+        sa.Column("one_way", sa.Boolean(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("metadata_json", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["start_node_id"], ["dt_nodes.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["end_node_id"], ["dt_nodes.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Create indexes for dt_edges table
+    op.create_index(
+        "idx_dt_edges_geometry_gist",
+        "dt_edges",
+        ["geometry"],
+        unique=False,
+        postgresql_using="gist",
+    )
+    op.create_index("idx_dt_edges_road_type", "dt_edges", ["road_type"], unique=False)
+    op.create_index(
+        "idx_dt_edges_start_node_id", "dt_edges", ["start_node_id"], unique=False
+    )
+    op.create_index(
+        "idx_dt_edges_end_node_id", "dt_edges", ["end_node_id"], unique=False
+    )
+    op.create_index("idx_dt_edges_is_active", "dt_edges", ["is_active"], unique=False)
+
+
+def downgrade() -> None:
+    # Drop indexes for dt_edges
+    op.drop_index("idx_dt_edges_is_active", table_name="dt_edges")
+    op.drop_index("idx_dt_edges_end_node_id", table_name="dt_edges")
+    op.drop_index("idx_dt_edges_start_node_id", table_name="dt_edges")
+    op.drop_index("idx_dt_edges_road_type", table_name="dt_edges")
+    op.drop_index("idx_dt_edges_geometry_gist", table_name="dt_edges", postgresql_using="gist")
+
+    # Drop dt_edges table
+    op.drop_table("dt_edges")
+
+    # Drop indexes for dt_nodes
+    op.drop_index("idx_dt_nodes_is_active", table_name="dt_nodes")
+    op.drop_index("idx_dt_nodes_node_type", table_name="dt_nodes")
+    op.drop_index("idx_dt_nodes_position_gist", table_name="dt_nodes", postgresql_using="gist")
+
+    # Drop dt_nodes table
+    op.drop_table("dt_nodes")

--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -75,3 +75,53 @@ SQL_POSTGIS_VERSION = "SELECT PostGIS_Version()"
 
 # Database Connection Pool
 DB_POOL_RECYCLE_SECONDS = 3600
+
+# =============================================================================
+# Road Network Constants
+# =============================================================================
+
+# Spatial Reference System (EPSG:4326 - WGS84)
+SRID_WGS84 = 4326
+
+# Coordinate Bounds (WGS84)
+LONGITUDE_MIN = -180.0
+LONGITUDE_MAX = 180.0
+LATITUDE_MIN = -90.0
+LATITUDE_MAX = 90.0
+
+# Road Network Table Names (prefixed with dt_ to avoid PostGIS Tiger conflicts)
+TABLE_NODES = "dt_nodes"
+TABLE_EDGES = "dt_edges"
+
+# Road Network Field Constraints
+NODE_NAME_MAX_LENGTH = 255
+EDGE_NAME_MAX_LENGTH = 255
+TYPE_FIELD_MAX_LENGTH = 50
+
+# Edge Default Values
+DEFAULT_MAX_SPEED_KMH = 50
+DEFAULT_LANES = 1
+DEFAULT_ONE_WAY = False
+DEFAULT_IS_ACTIVE = True
+
+# Edge Validation Constraints
+MIN_SPEED_KMH = 1
+MAX_SPEED_KMH = 300
+MIN_LANES = 1
+MAX_LANES = 10
+MIN_GEOMETRY_POINTS = 2
+
+# Index Names (dt_ prefix to avoid PostGIS Tiger conflicts)
+IDX_NODES_POSITION = "idx_dt_nodes_position_gist"
+IDX_NODES_TYPE = "idx_dt_nodes_node_type"
+IDX_NODES_ACTIVE = "idx_dt_nodes_is_active"
+IDX_EDGES_GEOMETRY = "idx_dt_edges_geometry_gist"
+IDX_EDGES_ROAD_TYPE = "idx_dt_edges_road_type"
+IDX_EDGES_START_NODE = "idx_dt_edges_start_node_id"
+IDX_EDGES_END_NODE = "idx_dt_edges_end_node_id"
+IDX_EDGES_ACTIVE = "idx_dt_edges_is_active"
+
+# API Tags for Road Network
+TAG_NODES = "Nodes"
+TAG_EDGES = "Edges"
+TAG_ROAD_NETWORK = "Road Network"

--- a/app/core/schemas/__init__.py
+++ b/app/core/schemas/__init__.py
@@ -1,0 +1,21 @@
+"""
+Pydantic schemas for the application.
+"""
+
+from app.core.schemas.network_schema import (
+    EdgeCreate,
+    EdgeResponse,
+    EdgeUpdate,
+    NodeCreate,
+    NodeResponse,
+    NodeUpdate,
+)
+
+__all__ = [
+    "NodeCreate",
+    "NodeResponse",
+    "NodeUpdate",
+    "EdgeCreate",
+    "EdgeResponse",
+    "EdgeUpdate",
+]

--- a/app/core/schemas/network_schema.py
+++ b/app/core/schemas/network_schema.py
@@ -1,0 +1,192 @@
+"""
+Pydantic schemas for road network entities (nodes and edges).
+Provides validation and serialization for API requests and responses.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.core.constants import (
+    DEFAULT_IS_ACTIVE,
+    DEFAULT_LANES,
+    DEFAULT_MAX_SPEED_KMH,
+    DEFAULT_ONE_WAY,
+    EDGE_NAME_MAX_LENGTH,
+    LATITUDE_MAX,
+    LATITUDE_MIN,
+    LONGITUDE_MAX,
+    LONGITUDE_MIN,
+    MAX_LANES,
+    MAX_SPEED_KMH,
+    MIN_GEOMETRY_POINTS,
+    MIN_LANES,
+    MIN_SPEED_KMH,
+    NODE_NAME_MAX_LENGTH,
+)
+from app.models.enums import NodeType, RoadType
+
+
+# ============================================================================
+# Coordinate Schema (reusable)
+# ============================================================================
+
+
+class Coordinate(BaseModel):
+    """Represents a geographic coordinate (WGS84 - EPSG:4326)."""
+
+    longitude: float = Field(
+        ..., ge=LONGITUDE_MIN, le=LONGITUDE_MAX, description="Longitude in degrees"
+    )
+    latitude: float = Field(
+        ..., ge=LATITUDE_MIN, le=LATITUDE_MAX, description="Latitude in degrees"
+    )
+
+
+# ============================================================================
+# Node Schemas
+# ============================================================================
+
+
+class NodeBase(BaseModel):
+    """Base schema for node attributes."""
+
+    name: Optional[str] = Field(
+        None, max_length=NODE_NAME_MAX_LENGTH, description="Node name"
+    )
+    node_type: NodeType = Field(
+        default=NodeType.INTERSECTION, description="Type of node"
+    )
+    is_active: bool = Field(
+        default=DEFAULT_IS_ACTIVE, description="Whether the node is active"
+    )
+    metadata_json: Optional[str] = Field(None, description="Optional JSON metadata")
+
+
+class NodeCreate(NodeBase):
+    """Schema for creating a new node."""
+
+    longitude: float = Field(
+        ..., ge=LONGITUDE_MIN, le=LONGITUDE_MAX, description="Longitude in degrees"
+    )
+    latitude: float = Field(
+        ..., ge=LATITUDE_MIN, le=LATITUDE_MAX, description="Latitude in degrees"
+    )
+
+
+class NodeUpdate(BaseModel):
+    """Schema for updating a node. All fields are optional."""
+
+    name: Optional[str] = Field(
+        None, max_length=NODE_NAME_MAX_LENGTH, description="Node name"
+    )
+    node_type: Optional[NodeType] = Field(None, description="Type of node")
+    longitude: Optional[float] = Field(
+        None, ge=LONGITUDE_MIN, le=LONGITUDE_MAX, description="Longitude in degrees"
+    )
+    latitude: Optional[float] = Field(
+        None, ge=LATITUDE_MIN, le=LATITUDE_MAX, description="Latitude in degrees"
+    )
+    is_active: Optional[bool] = Field(None, description="Whether the node is active")
+    metadata_json: Optional[str] = Field(None, description="Optional JSON metadata")
+
+
+class NodeResponse(NodeBase):
+    """Schema for node responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Unique node identifier")
+    longitude: float = Field(..., description="Longitude in degrees")
+    latitude: float = Field(..., description="Latitude in degrees")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+
+# ============================================================================
+# Edge Schemas
+# ============================================================================
+
+
+class EdgeBase(BaseModel):
+    """Base schema for edge attributes."""
+
+    name: Optional[str] = Field(
+        None, max_length=EDGE_NAME_MAX_LENGTH, description="Edge/road name"
+    )
+    road_type: RoadType = Field(
+        default=RoadType.RESIDENTIAL, description="Type of road"
+    )
+    max_speed: int = Field(
+        default=DEFAULT_MAX_SPEED_KMH,
+        ge=MIN_SPEED_KMH,
+        le=MAX_SPEED_KMH,
+        description="Maximum speed in km/h",
+    )
+    lanes: int = Field(
+        default=DEFAULT_LANES,
+        ge=MIN_LANES,
+        le=MAX_LANES,
+        description="Number of lanes",
+    )
+    one_way: bool = Field(
+        default=DEFAULT_ONE_WAY, description="Whether road is one-way"
+    )
+    is_active: bool = Field(
+        default=DEFAULT_IS_ACTIVE, description="Whether edge is active"
+    )
+    metadata_json: Optional[str] = Field(None, description="Optional JSON metadata")
+
+
+class EdgeCreate(EdgeBase):
+    """Schema for creating a new edge."""
+
+    start_node_id: int = Field(..., description="ID of the start node")
+    end_node_id: int = Field(..., description="ID of the end node")
+    geometry_coordinates: list[Coordinate] = Field(
+        ...,
+        min_length=MIN_GEOMETRY_POINTS,
+        description="List of coordinates forming the LineString geometry",
+    )
+    length: float = Field(..., gt=0, description="Length in meters")
+
+
+class EdgeUpdate(BaseModel):
+    """Schema for updating an edge. All fields are optional."""
+
+    name: Optional[str] = Field(
+        None, max_length=EDGE_NAME_MAX_LENGTH, description="Edge/road name"
+    )
+    road_type: Optional[RoadType] = Field(None, description="Type of road")
+    geometry_coordinates: Optional[list[Coordinate]] = Field(
+        None,
+        min_length=MIN_GEOMETRY_POINTS,
+        description="List of coordinates forming the geometry",
+    )
+    length: Optional[float] = Field(None, gt=0, description="Length in meters")
+    max_speed: Optional[int] = Field(
+        None, ge=MIN_SPEED_KMH, le=MAX_SPEED_KMH, description="Maximum speed in km/h"
+    )
+    lanes: Optional[int] = Field(
+        None, ge=MIN_LANES, le=MAX_LANES, description="Number of lanes"
+    )
+    one_way: Optional[bool] = Field(None, description="Whether road is one-way")
+    is_active: Optional[bool] = Field(None, description="Whether edge is active")
+    metadata_json: Optional[str] = Field(None, description="Optional JSON metadata")
+
+
+class EdgeResponse(EdgeBase):
+    """Schema for edge responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Unique edge identifier")
+    start_node_id: int = Field(..., description="ID of the start node")
+    end_node_id: int = Field(..., description="ID of the end node")
+    geometry_coordinates: list[Coordinate] = Field(
+        ..., description="List of coordinates forming the geometry"
+    )
+    length: float = Field(..., description="Length in meters")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,13 @@
+"""
+SQLAlchemy models for the application.
+"""
+
+from app.models.enums import NodeType, RoadType
+from app.models.road_network import EdgeModel, NodeModel
+
+__all__ = [
+    "NodeType",
+    "RoadType",
+    "NodeModel",
+    "EdgeModel",
+]

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -1,0 +1,31 @@
+"""
+Enums for road network models.
+Defines node and road types for the traffic simulation.
+"""
+
+from enum import Enum
+
+
+class NodeType(str, Enum):
+    """Types of nodes in the road network."""
+
+    INTERSECTION = "intersection"
+    ENDPOINT = "endpoint"
+    TRAFFIC_LIGHT = "traffic_light"
+    ROUNDABOUT = "roundabout"
+    DEAD_END = "dead_end"
+    ENTRY_POINT = "entry_point"
+    EXIT_POINT = "exit_point"
+
+
+class RoadType(str, Enum):
+    """Types of roads/edges in the network."""
+
+    MOTORWAY = "motorway"
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
+    TERTIARY = "tertiary"
+    RESIDENTIAL = "residential"
+    SERVICE = "service"
+    PEDESTRIAN = "pedestrian"
+    CYCLEWAY = "cycleway"

--- a/app/models/road_network.py
+++ b/app/models/road_network.py
@@ -1,0 +1,193 @@
+"""
+SQLAlchemy models for road network (nodes and edges).
+Uses GeoAlchemy2 for PostGIS geometry types with EPSG:4326 (WGS84).
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from geoalchemy2 import Geometry
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.constants import (
+    DEFAULT_IS_ACTIVE,
+    DEFAULT_LANES,
+    DEFAULT_MAX_SPEED_KMH,
+    DEFAULT_ONE_WAY,
+    EDGE_NAME_MAX_LENGTH,
+    IDX_EDGES_ACTIVE,
+    IDX_EDGES_END_NODE,
+    IDX_EDGES_GEOMETRY,
+    IDX_EDGES_ROAD_TYPE,
+    IDX_EDGES_START_NODE,
+    IDX_NODES_ACTIVE,
+    IDX_NODES_POSITION,
+    IDX_NODES_TYPE,
+    NODE_NAME_MAX_LENGTH,
+    SRID_WGS84,
+    TABLE_EDGES,
+    TABLE_NODES,
+    TYPE_FIELD_MAX_LENGTH,
+)
+from app.db.database import Base
+from app.models.enums import NodeType, RoadType
+
+
+class NodeModel(Base):
+    """
+    Represents a node (intersection, traffic light, etc.) in the road network.
+
+    Attributes:
+        id: Unique identifier
+        name: Optional human-readable name
+        node_type: Type of node (intersection, traffic_light, etc.)
+        position: PostGIS Point geometry (EPSG:4326 - WGS84)
+        is_active: Whether the node is currently active
+        metadata_json: Optional JSON metadata for additional properties
+        created_at: Timestamp of creation
+        updated_at: Timestamp of last update
+    """
+
+    __tablename__ = TABLE_NODES
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[Optional[str]] = mapped_column(
+        String(NODE_NAME_MAX_LENGTH), nullable=True
+    )
+    node_type: Mapped[str] = mapped_column(
+        String(TYPE_FIELD_MAX_LENGTH),
+        nullable=False,
+        default=NodeType.INTERSECTION.value,
+    )
+    position: Mapped[str] = mapped_column(
+        Geometry(geometry_type="POINT", srid=SRID_WGS84), nullable=False
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, default=DEFAULT_IS_ACTIVE, nullable=False
+    )
+    metadata_json: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationships
+    outgoing_edges: Mapped[list["EdgeModel"]] = relationship(
+        "EdgeModel",
+        foreign_keys="EdgeModel.start_node_id",
+        back_populates="start_node",
+        cascade="all, delete-orphan",
+    )
+    incoming_edges: Mapped[list["EdgeModel"]] = relationship(
+        "EdgeModel",
+        foreign_keys="EdgeModel.end_node_id",
+        back_populates="end_node",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index(IDX_NODES_POSITION, position, postgresql_using="gist"),
+        Index(IDX_NODES_TYPE, node_type),
+        Index(IDX_NODES_ACTIVE, is_active),
+    )
+
+    def __repr__(self) -> str:
+        return f"<NodeModel(id={self.id}, name={self.name}, type={self.node_type})>"
+
+
+class EdgeModel(Base):
+    """
+    Represents an edge (road segment) connecting two nodes in the road network.
+
+    Attributes:
+        id: Unique identifier
+        name: Optional human-readable name (e.g., street name)
+        start_node_id: ID of the starting node
+        end_node_id: ID of the ending node
+        road_type: Type of road (motorway, primary, etc.)
+        geometry: PostGIS LineString geometry (EPSG:4326 - WGS84)
+        length: Length of the edge in meters
+        max_speed: Maximum allowed speed in km/h
+        lanes: Number of lanes
+        one_way: Whether the road is one-way
+        is_active: Whether the edge is currently active
+        metadata_json: Optional JSON metadata for additional properties
+        created_at: Timestamp of creation
+        updated_at: Timestamp of last update
+    """
+
+    __tablename__ = TABLE_EDGES
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[Optional[str]] = mapped_column(
+        String(EDGE_NAME_MAX_LENGTH), nullable=True
+    )
+    start_node_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey(f"{TABLE_NODES}.id", ondelete="CASCADE"), nullable=False
+    )
+    end_node_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey(f"{TABLE_NODES}.id", ondelete="CASCADE"), nullable=False
+    )
+    road_type: Mapped[str] = mapped_column(
+        String(TYPE_FIELD_MAX_LENGTH),
+        nullable=False,
+        default=RoadType.RESIDENTIAL.value,
+    )
+    geometry: Mapped[str] = mapped_column(
+        Geometry(geometry_type="LINESTRING", srid=SRID_WGS84), nullable=False
+    )
+    length: Mapped[float] = mapped_column(Float, nullable=False)
+    max_speed: Mapped[int] = mapped_column(
+        Integer, default=DEFAULT_MAX_SPEED_KMH, nullable=False
+    )
+    lanes: Mapped[int] = mapped_column(Integer, default=DEFAULT_LANES, nullable=False)
+    one_way: Mapped[bool] = mapped_column(
+        Boolean, default=DEFAULT_ONE_WAY, nullable=False
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, default=DEFAULT_IS_ACTIVE, nullable=False
+    )
+    metadata_json: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationships
+    start_node: Mapped["NodeModel"] = relationship(
+        "NodeModel", foreign_keys=[start_node_id], back_populates="outgoing_edges"
+    )
+    end_node: Mapped["NodeModel"] = relationship(
+        "NodeModel", foreign_keys=[end_node_id], back_populates="incoming_edges"
+    )
+
+    __table_args__ = (
+        Index(IDX_EDGES_GEOMETRY, geometry, postgresql_using="gist"),
+        Index(IDX_EDGES_ROAD_TYPE, road_type),
+        Index(IDX_EDGES_START_NODE, start_node_id),
+        Index(IDX_EDGES_END_NODE, end_node_id),
+        Index(IDX_EDGES_ACTIVE, is_active),
+    )
+
+    def __repr__(self) -> str:
+        return f"<EdgeModel(id={self.id}, name={self.name}, type={self.road_type})>"

--- a/doc/sprint2/road-network-models.md
+++ b/doc/sprint2/road-network-models.md
@@ -1,0 +1,332 @@
+# Road Network Data Models (Nodes & Edges)
+
+## Overview
+
+This document describes the road network data models implemented for the Digital Twin Traffic Backend. The models represent the road network as a directed graph where:
+
+- **Nodes**: Represent intersections, traffic lights, roundabouts, entry/exit points
+- **Edges**: Represent road segments connecting nodes
+
+## Entity-Relationship Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                            DT_NODES                                 │
+├─────────────────────────────────────────────────────────────────────┤
+│ PK  id              INTEGER        AUTO_INCREMENT                   │
+│     name            VARCHAR(255)   NULLABLE                         │
+│     node_type       VARCHAR(50)    NOT NULL (NodeType enum)         │
+│     position        POINT(4326)    NOT NULL (PostGIS)               │
+│     is_active       BOOLEAN        NOT NULL DEFAULT TRUE            │
+│     metadata_json   TEXT           NULLABLE                         │
+│     created_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()           │
+│     updated_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()           │
+├─────────────────────────────────────────────────────────────────────┤
+│ INDEXES:                                                            │
+│   - idx_dt_nodes_position_gist (GIST on position)                   │
+│   - idx_dt_nodes_node_type (BTREE on node_type)                     │
+│   - idx_dt_nodes_is_active (BTREE on is_active)                     │
+└─────────────────────────────────────────────────────────────────────┘
+                          │
+                          │ 1:N (start_node)
+                          │ 1:N (end_node)
+                          ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                            DT_EDGES                                 │
+├─────────────────────────────────────────────────────────────────────┤
+│ PK  id              INTEGER        AUTO_INCREMENT                   │
+│     name            VARCHAR(255)   NULLABLE                         │
+│ FK  start_node_id   INTEGER        NOT NULL → dt_nodes.id CASCADE   │
+│ FK  end_node_id     INTEGER        NOT NULL → dt_nodes.id CASCADE   │
+│     road_type       VARCHAR(50)    NOT NULL (RoadType enum)         │
+│     geometry        LINESTRING(4326) NOT NULL (PostGIS)             │
+│     length          FLOAT          NOT NULL                         │
+│     max_speed       INTEGER        NOT NULL DEFAULT 50              │
+│     lanes           INTEGER        NOT NULL DEFAULT 1               │
+│     one_way         BOOLEAN        NOT NULL DEFAULT FALSE           │
+│     is_active       BOOLEAN        NOT NULL DEFAULT TRUE            │
+│     metadata_json   TEXT           NULLABLE                         │
+│     created_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()           │
+│     updated_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()           │
+├─────────────────────────────────────────────────────────────────────┤
+│ INDEXES:                                                            │
+│   - idx_dt_edges_geometry_gist (GIST on geometry)                   │
+│   - idx_dt_edges_road_type (BTREE on road_type)                     │
+│   - idx_dt_edges_start_node_id (BTREE on start_node_id)             │
+│   - idx_dt_edges_end_node_id (BTREE on end_node_id)                 │
+│   - idx_dt_edges_is_active (BTREE on is_active)                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+> **Note**: Table names use the `dt_` prefix to avoid conflicts with PostGIS Tiger geocoder tables (`tiger.edges`, `tiger.nodes`).
+
+## Enums
+
+### NodeType
+
+Defines the types of nodes in the road network:
+
+| Value | Description |
+|-------|-------------|
+| `intersection` | Standard road intersection |
+| `endpoint` | Generic endpoint (start/end of road) |
+| `traffic_light` | Intersection with traffic signals |
+| `roundabout` | Circular intersection |
+| `dead_end` | End of road with no exit |
+| `entry_point` | Entry point to the simulation area |
+| `exit_point` | Exit point from the simulation area |
+
+### RoadType
+
+Defines the types of roads/edges:
+
+| Value | Description |
+|-------|-------------|
+| `motorway` | Major highway/motorway |
+| `primary` | Primary road (main arterial) |
+| `secondary` | Secondary road |
+| `tertiary` | Tertiary road |
+| `residential` | Residential street |
+| `service` | Service road |
+| `pedestrian` | Pedestrian-only path |
+| `cycleway` | Bicycle path |
+
+## PostGIS Geometry Types
+
+### SRID 4326 (WGS84)
+
+All geometries use EPSG:4326 (WGS84) coordinate reference system:
+
+- **Node.position**: `POINT` - Single geographic point (longitude, latitude)
+- **Edge.geometry**: `LINESTRING` - Sequence of connected points forming the road path
+
+### Spatial Indexes
+
+GIST indexes are created on geometry columns for efficient spatial queries:
+
+```sql
+-- Find nodes within a bounding box
+SELECT * FROM dt_nodes
+WHERE ST_Within(position, ST_MakeEnvelope(-4.85, 39.95, -4.80, 40.00, 4326));
+
+-- Find edges intersecting an area
+SELECT * FROM dt_edges
+WHERE ST_Intersects(geometry, ST_MakeEnvelope(-4.85, 39.95, -4.80, 40.00, 4326));
+```
+
+## Constants
+
+All magic numbers and repeated values are centralized in `app/core/constants.py`:
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SRID_WGS84` | 4326 | Spatial Reference System ID |
+| `TABLE_NODES` | "dt_nodes" | Nodes table name |
+| `TABLE_EDGES` | "dt_edges" | Edges table name |
+| `NODE_NAME_MAX_LENGTH` | 255 | Max chars for node name |
+| `EDGE_NAME_MAX_LENGTH` | 255 | Max chars for edge name |
+| `TYPE_FIELD_MAX_LENGTH` | 50 | Max chars for type fields |
+| `DEFAULT_MAX_SPEED_KMH` | 50 | Default speed limit |
+| `DEFAULT_LANES` | 1 | Default number of lanes |
+| `DEFAULT_ONE_WAY` | False | Default one-way value |
+| `DEFAULT_IS_ACTIVE` | True | Default active status |
+| `MIN_SPEED_KMH` | 1 | Minimum speed validation |
+| `MAX_SPEED_KMH` | 300 | Maximum speed validation |
+| `MIN_LANES` | 1 | Minimum lanes validation |
+| `MAX_LANES` | 10 | Maximum lanes validation |
+| `MIN_GEOMETRY_POINTS` | 2 | Minimum points in LineString |
+
+## File Structure
+
+```
+app/
+├── core/
+│   ├── constants.py            # Global constants (SRID, table names, defaults)
+│   └── schemas/
+│       ├── __init__.py         # Schema exports
+│       └── network_schema.py   # Pydantic schemas for API validation
+├── models/
+│   ├── __init__.py             # Exports NodeModel, EdgeModel, NodeType, RoadType
+│   ├── enums.py                # NodeType and RoadType enums
+│   └── road_network.py         # SQLAlchemy models (NodeModel, EdgeModel)
+└── db/
+    └── database.py             # Base class for models
+
+alembic/
+└── versions/
+    └── 001_create_road_network_tables.py  # Migration file
+
+tests/
+├── fixtures/
+│   ├── __init__.py
+│   └── road_network_fixtures.py  # Sample data for testing
+└── test_road_network_models.py   # Unit tests
+```
+
+## Pydantic Schemas
+
+### Node Schemas
+
+| Schema | Purpose |
+|--------|---------|
+| `NodeCreate` | Create new node (longitude, latitude required) |
+| `NodeUpdate` | Update existing node (all fields optional) |
+| `NodeResponse` | API response with full node data |
+
+### Edge Schemas
+
+| Schema | Purpose |
+|--------|---------|
+| `EdgeCreate` | Create new edge (start/end nodes, geometry required) |
+| `EdgeUpdate` | Update existing edge (all fields optional) |
+| `EdgeResponse` | API response with full edge data |
+
+### Coordinate Schema
+
+```python
+from app.core.constants import LONGITUDE_MIN, LONGITUDE_MAX, LATITUDE_MIN, LATITUDE_MAX
+
+class Coordinate(BaseModel):
+    longitude: float  # LONGITUDE_MIN (-180) to LONGITUDE_MAX (180)
+    latitude: float   # LATITUDE_MIN (-90) to LATITUDE_MAX (90)
+```
+
+## Usage Examples
+
+### Creating a Node
+
+```python
+from app.core.schemas.network_schema import NodeCreate
+from app.models.enums import NodeType
+
+node_data = NodeCreate(
+    name="Plaza del Pan",
+    node_type=NodeType.INTERSECTION,
+    longitude=-4.8306,
+    latitude=39.9634,
+    is_active=True
+)
+```
+
+### Creating an Edge
+
+```python
+from app.core.schemas.network_schema import EdgeCreate, Coordinate
+from app.models.enums import RoadType
+
+edge_data = EdgeCreate(
+    name="Calle Real",
+    start_node_id=1,
+    end_node_id=2,
+    road_type=RoadType.PRIMARY,
+    geometry_coordinates=[
+        Coordinate(longitude=-4.8306, latitude=39.9634),
+        Coordinate(longitude=-4.8320, latitude=39.9640),
+    ],
+    length=150.0,
+    max_speed=50,
+    lanes=2
+)
+```
+
+## Database Migration
+
+Run the migration to create the tables:
+
+```bash
+# Ensure PostgreSQL with PostGIS is running
+docker-compose up -d postgres
+
+# Run migration
+alembic upgrade head
+```
+
+Verify tables were created:
+
+```sql
+-- Check tables exist
+\dt dt_nodes
+\dt dt_edges
+
+-- Check PostGIS indexes
+\di idx_dt_nodes_position_gist
+\di idx_dt_edges_geometry_gist
+```
+
+## Testing
+
+Run the unit tests:
+
+```bash
+# Run all road network tests
+pytest tests/test_road_network_models.py -v
+
+# Run only unit tests
+pytest tests/test_road_network_models.py -v -m unit
+
+# Run full test suite
+pytest -v
+```
+
+### Test Coverage
+
+| Test Class | Tests | Description |
+|------------|-------|-------------|
+| `TestNodeTypeEnum` | 2 | Enum values and string type |
+| `TestRoadTypeEnum` | 2 | Enum values and string type |
+| `TestCoordinateSchema` | 3 | Coordinate validation bounds |
+| `TestNodeSchemas` | 7 | Node create/update/response |
+| `TestEdgeSchemas` | 7 | Edge create/update/response |
+| `TestSampleFixtures` | 6 | Sample data helpers |
+| **Total** | **27** | |
+
+## Sample Data
+
+The fixtures module provides sample data based on Talavera de la Reina coordinates:
+
+- 6 sample nodes (intersections, traffic lights, roundabouts, entry/exit points)
+- 4 sample edges connecting the nodes
+
+```python
+from tests.fixtures.road_network_fixtures import (
+    SAMPLE_NODES,
+    SAMPLE_EDGES,
+    create_sample_node_data,
+    create_sample_edge_data,
+    TALAVERA_CENTER_LON,
+    TALAVERA_CENTER_LAT,
+)
+
+# Use in tests
+for node_data in SAMPLE_NODES:
+    node = NodeCreate(**node_data)
+
+# Create custom test data
+custom_node = create_sample_node_data(
+    name="Custom Node",
+    node_type=NodeType.ROUNDABOUT.value,
+    longitude=-4.8200,
+    latitude=39.9700,
+)
+```
+
+## Validation Rules
+
+### Node Validation
+
+| Field | Rule |
+|-------|------|
+| `longitude` | -180.0 to 180.0 |
+| `latitude` | -90.0 to 90.0 |
+| `name` | Max 255 characters |
+| `node_type` | Must be valid NodeType enum value |
+
+### Edge Validation
+
+| Field | Rule |
+|-------|------|
+| `geometry_coordinates` | Minimum 2 points |
+| `length` | Must be > 0 |
+| `max_speed` | 1 to 300 km/h |
+| `lanes` | 1 to 10 |
+| `road_type` | Must be valid RoadType enum value |

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -35,8 +35,12 @@ httpx==0.28.1
 ```
 tests/
 ├── __init__.py
-├── test_health.py       # Tests de endpoints de health check
-└── test_websocket.py    # Tests de WebSocket y ConnectionManager
+├── fixtures/
+│   ├── __init__.py
+│   └── road_network_fixtures.py  # Sample data for road network testing
+├── test_health.py                # Tests de endpoints de health check
+├── test_road_network_models.py   # Tests de modelos de red vial
+└── test_websocket.py             # Tests de WebSocket y ConnectionManager
 ```
 
 ## Catalogo de Tests
@@ -69,6 +73,40 @@ Tests para el WebSocket Connection Manager y endpoints de comunicacion en tiempo
 | `TestWebSocketEndpoint::test_websocket_json_message_structure` | unit | Valida estructura JSON de respuestas |
 | `TestWebSocketEndpoint::test_websocket_simulation_data` | integration | Simula datos de vehiculos con posicion y velocidad |
 
+### test_road_network_models.py
+
+Tests para modelos de red vial (nodos y aristas), enums y schemas Pydantic.
+
+| Test | Marker | Descripcion |
+|------|--------|-------------|
+| `TestNodeTypeEnum::test_node_type_values` | unit | Verifica valores del enum NodeType |
+| `TestNodeTypeEnum::test_node_type_is_string_enum` | unit | Verifica que NodeType es string enum |
+| `TestRoadTypeEnum::test_road_type_values` | unit | Verifica valores del enum RoadType |
+| `TestRoadTypeEnum::test_road_type_is_string_enum` | unit | Verifica que RoadType es string enum |
+| `TestCoordinateSchema::test_valid_coordinate` | unit | Verifica creacion de coordenadas validas |
+| `TestCoordinateSchema::test_coordinate_bounds_longitude` | unit | Valida limites de longitud (-180 a 180) |
+| `TestCoordinateSchema::test_coordinate_bounds_latitude` | unit | Valida limites de latitud (-90 a 90) |
+| `TestNodeSchemas::test_node_create_valid` | unit | Verifica schema NodeCreate completo |
+| `TestNodeSchemas::test_node_create_minimal` | unit | Verifica NodeCreate con campos minimos |
+| `TestNodeSchemas::test_node_create_invalid_longitude` | unit | Rechaza longitud invalida |
+| `TestNodeSchemas::test_node_create_invalid_latitude` | unit | Rechaza latitud invalida |
+| `TestNodeSchemas::test_node_update_all_optional` | unit | Verifica NodeUpdate con campos opcionales |
+| `TestNodeSchemas::test_node_update_partial` | unit | Verifica actualizacion parcial de nodo |
+| `TestNodeSchemas::test_node_response_from_dict` | unit | Verifica NodeResponse desde diccionario |
+| `TestEdgeSchemas::test_edge_create_valid` | unit | Verifica schema EdgeCreate completo |
+| `TestEdgeSchemas::test_edge_create_minimal` | unit | Verifica EdgeCreate con campos minimos |
+| `TestEdgeSchemas::test_edge_create_invalid_geometry_too_few_points` | unit | Rechaza geometria con menos de 2 puntos |
+| `TestEdgeSchemas::test_edge_create_invalid_length` | unit | Rechaza longitud <= 0 |
+| `TestEdgeSchemas::test_edge_create_invalid_speed` | unit | Rechaza velocidad maxima < 1 |
+| `TestEdgeSchemas::test_edge_update_all_optional` | unit | Verifica EdgeUpdate con campos opcionales |
+| `TestEdgeSchemas::test_edge_response_from_dict` | unit | Verifica EdgeResponse desde diccionario |
+| `TestSampleFixtures::test_sample_nodes_count` | unit | Verifica cantidad de nodos de ejemplo (6) |
+| `TestSampleFixtures::test_sample_nodes_valid_schema` | unit | Valida schemas de nodos de ejemplo |
+| `TestSampleFixtures::test_sample_edges_count` | unit | Verifica cantidad de aristas de ejemplo (4) |
+| `TestSampleFixtures::test_sample_edges_valid_references` | unit | Valida referencias a nodos en aristas |
+| `TestSampleFixtures::test_create_sample_node_data_helper` | unit | Verifica helper create_sample_node_data |
+| `TestSampleFixtures::test_create_sample_edge_data_helper` | unit | Verifica helper create_sample_edge_data |
+
 ## Cobertura por Modulo
 
 | Modulo | Tests | Cobertura |
@@ -78,6 +116,9 @@ Tests para el WebSocket Connection Manager y endpoints de comunicacion en tiempo
 | `app/api/websocket/manager.py` | 2 | Clase `ConnectionManager` |
 | `app/api/routes.py` | 6 | Endpoint WebSocket `/ws/simulation` |
 | `app/core/responses.py` | 1 | Modelo `DatabaseHealthResponse` |
+| `app/models/enums.py` | 4 | Enums `NodeType` y `RoadType` |
+| `app/core/schemas/network_schema.py` | 14 | Schemas de red vial (Node*, Edge*, Coordinate) |
+| `tests/fixtures/road_network_fixtures.py` | 6 | Helpers y datos de ejemplo |
 | `app/db/` | - | Mockeado en tests unitarios |
 
 ## Estrategia de Mocking
@@ -212,36 +253,36 @@ configfile: pytest.ini
 testpaths: tests
 plugins: anyio-4.12.1, asyncio-0.25.2
 asyncio: mode=Mode.STRICT
-collected 14 items
+collected 41 items
 
-tests/test_health.py::test_root_endpoint PASSED                  [  7%]
-tests/test_health.py::test_health_check PASSED                   [ 14%]
-tests/test_health.py::test_detailed_health_check PASSED          [ 21%]
-tests/test_health.py::test_health_check_returns_correct_structure PASSED [ 28%]
-tests/test_health.py::test_detailed_health_check_returns_correct_structure PASSED [ 35%]
-tests/test_health.py::test_database_health_response_model PASSED [ 42%]
-tests/test_websocket.py::TestConnectionManager::test_connection_manager_initialization PASSED [ 50%]
-tests/test_websocket.py::TestConnectionManager::test_connection_count_property PASSED [ 57%]
-tests/test_websocket.py::TestWebSocketEndpoint::test_websocket_connection PASSED [ 64%]
-tests/test_websocket.py::TestWebSocketEndpoint::test_websocket_echo_message PASSED [ 71%]
-tests/test_websocket.py::TestWebSocketEndpoint::test_websocket_multiple_messages PASSED [ 78%]
-tests/test_websocket.py::TestWebSocketEndpoint::test_websocket_connection_lifecycle PASSED [ 85%]
-tests/test_websocket.py::TestWebSocketEndpoint::test_websocket_json_message_structure PASSED [ 92%]
-tests/test_websocket.py::TestWebSocketEndpoint::test_websocket_simulation_data PASSED [100%]
+tests/test_health.py::test_root_endpoint PASSED                    [  2%]
+tests/test_health.py::test_health_check PASSED                     [  4%]
+tests/test_health.py::test_detailed_health_check PASSED            [  7%]
+tests/test_health.py::test_health_check_returns_correct_structure PASSED [  9%]
+tests/test_health.py::test_detailed_health_check_returns_correct_structure PASSED [ 12%]
+tests/test_health.py::test_database_health_response_model PASSED   [ 14%]
+tests/test_road_network_models.py::TestNodeTypeEnum::* PASSED      [ 19%]
+tests/test_road_network_models.py::TestRoadTypeEnum::* PASSED      [ 24%]
+tests/test_road_network_models.py::TestCoordinateSchema::* PASSED  [ 31%]
+tests/test_road_network_models.py::TestNodeSchemas::* PASSED       [ 48%]
+tests/test_road_network_models.py::TestEdgeSchemas::* PASSED       [ 65%]
+tests/test_road_network_models.py::TestSampleFixtures::* PASSED    [ 80%]
+tests/test_websocket.py::TestConnectionManager::* PASSED           [ 85%]
+tests/test_websocket.py::TestWebSocketEndpoint::* PASSED           [100%]
 
-========================= 14 passed in 0.29s =========================
+========================= 41 passed in 0.36s =========================
 ```
 
 ### Resumen
 
 | Metrica | Valor |
 |---------|-------|
-| Total tests | 14 |
-| Passed | 14 |
+| Total tests | 41 |
+| Passed | 41 |
 | Failed | 0 |
 | Skipped | 0 |
-| Tiempo | 0.29s |
-| Cobertura | ~85% (estimado) |
+| Tiempo | 0.36s |
+| Cobertura | ~90% (estimado) |
 
 ## Tests por Endpoint
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,17 @@
+"""
+Test fixtures for the application.
+"""
+
+from tests.fixtures.road_network_fixtures import (
+    SAMPLE_EDGES,
+    SAMPLE_NODES,
+    create_sample_edge_data,
+    create_sample_node_data,
+)
+
+__all__ = [
+    "SAMPLE_NODES",
+    "SAMPLE_EDGES",
+    "create_sample_node_data",
+    "create_sample_edge_data",
+]

--- a/tests/fixtures/road_network_fixtures.py
+++ b/tests/fixtures/road_network_fixtures.py
@@ -1,0 +1,176 @@
+"""
+Sample data fixtures for road network testing.
+Based on Talavera de la Reina geographic coordinates.
+"""
+
+from app.models.enums import NodeType, RoadType
+
+# Talavera de la Reina approximate center coordinates
+TALAVERA_CENTER_LON = -4.8306
+TALAVERA_CENTER_LAT = 39.9634
+
+# Sample node data for testing
+SAMPLE_NODES = [
+    {
+        "name": "Plaza del Pan",
+        "node_type": NodeType.INTERSECTION.value,
+        "longitude": -4.8306,
+        "latitude": 39.9634,
+        "is_active": True,
+    },
+    {
+        "name": "Puente Romano",
+        "node_type": NodeType.INTERSECTION.value,
+        "longitude": -4.8256,
+        "latitude": 39.9598,
+        "is_active": True,
+    },
+    {
+        "name": "Semáforo Calle Real",
+        "node_type": NodeType.TRAFFIC_LIGHT.value,
+        "longitude": -4.8320,
+        "latitude": 39.9640,
+        "is_active": True,
+    },
+    {
+        "name": "Rotonda Hospital",
+        "node_type": NodeType.ROUNDABOUT.value,
+        "longitude": -4.8150,
+        "latitude": 39.9700,
+        "is_active": True,
+    },
+    {
+        "name": "Entrada A-5",
+        "node_type": NodeType.ENTRY_POINT.value,
+        "longitude": -4.8500,
+        "latitude": 39.9500,
+        "is_active": True,
+    },
+    {
+        "name": "Salida Toledo",
+        "node_type": NodeType.EXIT_POINT.value,
+        "longitude": -4.8000,
+        "latitude": 39.9800,
+        "is_active": True,
+    },
+]
+
+# Sample edge data for testing (references node indices 0-based)
+SAMPLE_EDGES = [
+    {
+        "name": "Calle Real",
+        "start_node_index": 0,  # Plaza del Pan
+        "end_node_index": 2,  # Semáforo Calle Real
+        "road_type": RoadType.PRIMARY.value,
+        "geometry_coordinates": [
+            {"longitude": -4.8306, "latitude": 39.9634},
+            {"longitude": -4.8320, "latitude": 39.9640},
+        ],
+        "length": 150.0,
+        "max_speed": 50,
+        "lanes": 2,
+        "one_way": False,
+        "is_active": True,
+    },
+    {
+        "name": "Avenida del Puente",
+        "start_node_index": 0,  # Plaza del Pan
+        "end_node_index": 1,  # Puente Romano
+        "road_type": RoadType.SECONDARY.value,
+        "geometry_coordinates": [
+            {"longitude": -4.8306, "latitude": 39.9634},
+            {"longitude": -4.8280, "latitude": 39.9616},
+            {"longitude": -4.8256, "latitude": 39.9598},
+        ],
+        "length": 450.0,
+        "max_speed": 40,
+        "lanes": 1,
+        "one_way": True,
+        "is_active": True,
+    },
+    {
+        "name": "Carretera Hospital",
+        "start_node_index": 2,  # Semáforo Calle Real
+        "end_node_index": 3,  # Rotonda Hospital
+        "road_type": RoadType.PRIMARY.value,
+        "geometry_coordinates": [
+            {"longitude": -4.8320, "latitude": 39.9640},
+            {"longitude": -4.8200, "latitude": 39.9680},
+            {"longitude": -4.8150, "latitude": 39.9700},
+        ],
+        "length": 800.0,
+        "max_speed": 60,
+        "lanes": 2,
+        "one_way": False,
+        "is_active": True,
+    },
+    {
+        "name": "Acceso A-5",
+        "start_node_index": 4,  # Entrada A-5
+        "end_node_index": 0,  # Plaza del Pan
+        "road_type": RoadType.MOTORWAY.value,
+        "geometry_coordinates": [
+            {"longitude": -4.8500, "latitude": 39.9500},
+            {"longitude": -4.8400, "latitude": 39.9560},
+            {"longitude": -4.8306, "latitude": 39.9634},
+        ],
+        "length": 2000.0,
+        "max_speed": 80,
+        "lanes": 2,
+        "one_way": True,
+        "is_active": True,
+    },
+]
+
+
+def create_sample_node_data(
+    name: str = "Test Node",
+    node_type: str = NodeType.INTERSECTION.value,
+    longitude: float = TALAVERA_CENTER_LON,
+    latitude: float = TALAVERA_CENTER_LAT,
+    is_active: bool = True,
+    metadata_json: str | None = None,
+) -> dict:
+    """Create sample node data for testing."""
+    return {
+        "name": name,
+        "node_type": node_type,
+        "longitude": longitude,
+        "latitude": latitude,
+        "is_active": is_active,
+        "metadata_json": metadata_json,
+    }
+
+
+def create_sample_edge_data(
+    name: str = "Test Edge",
+    start_node_id: int = 1,
+    end_node_id: int = 2,
+    road_type: str = RoadType.RESIDENTIAL.value,
+    geometry_coordinates: list | None = None,
+    length: float = 100.0,
+    max_speed: int = 50,
+    lanes: int = 1,
+    one_way: bool = False,
+    is_active: bool = True,
+    metadata_json: str | None = None,
+) -> dict:
+    """Create sample edge data for testing."""
+    if geometry_coordinates is None:
+        geometry_coordinates = [
+            {"longitude": TALAVERA_CENTER_LON, "latitude": TALAVERA_CENTER_LAT},
+            {"longitude": TALAVERA_CENTER_LON + 0.001, "latitude": TALAVERA_CENTER_LAT + 0.001},
+        ]
+    return {
+        "name": name,
+        "start_node_id": start_node_id,
+        "end_node_id": end_node_id,
+        "road_type": road_type,
+        "geometry_coordinates": geometry_coordinates,
+        "length": length,
+        "max_speed": max_speed,
+        "lanes": lanes,
+        "one_way": one_way,
+        "is_active": is_active,
+        "metadata_json": metadata_json,
+    }

--- a/tests/test_road_network_models.py
+++ b/tests/test_road_network_models.py
@@ -1,0 +1,366 @@
+"""
+Unit tests for road network models, enums, and schemas.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.enums import NodeType, RoadType
+from app.core.schemas.network_schema import (
+    Coordinate,
+    EdgeCreate,
+    EdgeResponse,
+    EdgeUpdate,
+    NodeCreate,
+    NodeResponse,
+    NodeUpdate,
+)
+from tests.fixtures.road_network_fixtures import (
+    SAMPLE_EDGES,
+    SAMPLE_NODES,
+    create_sample_edge_data,
+    create_sample_node_data,
+)
+
+
+# ============================================================================
+# Enum Tests
+# ============================================================================
+
+
+class TestNodeTypeEnum:
+    """Tests for NodeType enum."""
+
+    @pytest.mark.unit
+    def test_node_type_values(self):
+        """Test all NodeType enum values exist."""
+        assert NodeType.INTERSECTION.value == "intersection"
+        assert NodeType.ENDPOINT.value == "endpoint"
+        assert NodeType.TRAFFIC_LIGHT.value == "traffic_light"
+        assert NodeType.ROUNDABOUT.value == "roundabout"
+        assert NodeType.DEAD_END.value == "dead_end"
+        assert NodeType.ENTRY_POINT.value == "entry_point"
+        assert NodeType.EXIT_POINT.value == "exit_point"
+
+    @pytest.mark.unit
+    def test_node_type_is_string_enum(self):
+        """Test NodeType is a string enum."""
+        assert isinstance(NodeType.INTERSECTION, str)
+        assert NodeType.INTERSECTION == "intersection"
+
+
+class TestRoadTypeEnum:
+    """Tests for RoadType enum."""
+
+    @pytest.mark.unit
+    def test_road_type_values(self):
+        """Test all RoadType enum values exist."""
+        assert RoadType.MOTORWAY.value == "motorway"
+        assert RoadType.PRIMARY.value == "primary"
+        assert RoadType.SECONDARY.value == "secondary"
+        assert RoadType.TERTIARY.value == "tertiary"
+        assert RoadType.RESIDENTIAL.value == "residential"
+        assert RoadType.SERVICE.value == "service"
+        assert RoadType.PEDESTRIAN.value == "pedestrian"
+        assert RoadType.CYCLEWAY.value == "cycleway"
+
+    @pytest.mark.unit
+    def test_road_type_is_string_enum(self):
+        """Test RoadType is a string enum."""
+        assert isinstance(RoadType.MOTORWAY, str)
+        assert RoadType.MOTORWAY == "motorway"
+
+
+# ============================================================================
+# Coordinate Schema Tests
+# ============================================================================
+
+
+class TestCoordinateSchema:
+    """Tests for Coordinate schema."""
+
+    @pytest.mark.unit
+    def test_valid_coordinate(self):
+        """Test valid coordinate creation."""
+        coord = Coordinate(longitude=-4.8306, latitude=39.9634)
+        assert coord.longitude == -4.8306
+        assert coord.latitude == 39.9634
+
+    @pytest.mark.unit
+    def test_coordinate_bounds_longitude(self):
+        """Test longitude bounds validation."""
+        # Valid bounds
+        Coordinate(longitude=-180, latitude=0)
+        Coordinate(longitude=180, latitude=0)
+
+        # Invalid bounds
+        with pytest.raises(ValidationError):
+            Coordinate(longitude=-181, latitude=0)
+        with pytest.raises(ValidationError):
+            Coordinate(longitude=181, latitude=0)
+
+    @pytest.mark.unit
+    def test_coordinate_bounds_latitude(self):
+        """Test latitude bounds validation."""
+        # Valid bounds
+        Coordinate(longitude=0, latitude=-90)
+        Coordinate(longitude=0, latitude=90)
+
+        # Invalid bounds
+        with pytest.raises(ValidationError):
+            Coordinate(longitude=0, latitude=-91)
+        with pytest.raises(ValidationError):
+            Coordinate(longitude=0, latitude=91)
+
+
+# ============================================================================
+# Node Schema Tests
+# ============================================================================
+
+
+class TestNodeSchemas:
+    """Tests for Node schemas."""
+
+    @pytest.mark.unit
+    def test_node_create_valid(self):
+        """Test valid NodeCreate schema."""
+        data = create_sample_node_data()
+        node = NodeCreate(**data)
+        assert node.name == data["name"]
+        assert node.node_type == NodeType.INTERSECTION
+        assert node.longitude == data["longitude"]
+        assert node.latitude == data["latitude"]
+        assert node.is_active is True
+
+    @pytest.mark.unit
+    def test_node_create_minimal(self):
+        """Test NodeCreate with minimal required fields."""
+        node = NodeCreate(longitude=-4.8306, latitude=39.9634)
+        assert node.name is None
+        assert node.node_type == NodeType.INTERSECTION  # default
+        assert node.is_active is True  # default
+
+    @pytest.mark.unit
+    def test_node_create_invalid_longitude(self):
+        """Test NodeCreate with invalid longitude."""
+        with pytest.raises(ValidationError):
+            NodeCreate(longitude=-200, latitude=39.9634)
+
+    @pytest.mark.unit
+    def test_node_create_invalid_latitude(self):
+        """Test NodeCreate with invalid latitude."""
+        with pytest.raises(ValidationError):
+            NodeCreate(longitude=-4.8306, latitude=100)
+
+    @pytest.mark.unit
+    def test_node_update_all_optional(self):
+        """Test NodeUpdate with all fields optional."""
+        update = NodeUpdate()
+        assert update.name is None
+        assert update.node_type is None
+        assert update.longitude is None
+        assert update.latitude is None
+        assert update.is_active is None
+
+    @pytest.mark.unit
+    def test_node_update_partial(self):
+        """Test NodeUpdate with partial fields."""
+        update = NodeUpdate(name="Updated Name", is_active=False)
+        assert update.name == "Updated Name"
+        assert update.is_active is False
+        assert update.node_type is None
+
+    @pytest.mark.unit
+    def test_node_response_from_dict(self):
+        """Test NodeResponse creation from dictionary."""
+        from datetime import datetime
+
+        data = {
+            "id": 1,
+            "name": "Test Node",
+            "node_type": NodeType.TRAFFIC_LIGHT,
+            "longitude": -4.8306,
+            "latitude": 39.9634,
+            "is_active": True,
+            "metadata_json": None,
+            "created_at": datetime.now(),
+            "updated_at": datetime.now(),
+        }
+        response = NodeResponse(**data)
+        assert response.id == 1
+        assert response.name == "Test Node"
+        assert response.node_type == NodeType.TRAFFIC_LIGHT
+
+
+# ============================================================================
+# Edge Schema Tests
+# ============================================================================
+
+
+class TestEdgeSchemas:
+    """Tests for Edge schemas."""
+
+    @pytest.mark.unit
+    def test_edge_create_valid(self):
+        """Test valid EdgeCreate schema."""
+        data = create_sample_edge_data()
+        edge = EdgeCreate(**data)
+        assert edge.name == data["name"]
+        assert edge.start_node_id == data["start_node_id"]
+        assert edge.end_node_id == data["end_node_id"]
+        assert edge.road_type == RoadType.RESIDENTIAL
+        assert len(edge.geometry_coordinates) == 2
+
+    @pytest.mark.unit
+    def test_edge_create_minimal(self):
+        """Test EdgeCreate with minimal required fields."""
+        edge = EdgeCreate(
+            start_node_id=1,
+            end_node_id=2,
+            geometry_coordinates=[
+                Coordinate(longitude=-4.8306, latitude=39.9634),
+                Coordinate(longitude=-4.8256, latitude=39.9598),
+            ],
+            length=100.0,
+        )
+        assert edge.road_type == RoadType.RESIDENTIAL  # default
+        assert edge.max_speed == 50  # default
+        assert edge.lanes == 1  # default
+        assert edge.one_way is False  # default
+
+    @pytest.mark.unit
+    def test_edge_create_invalid_geometry_too_few_points(self):
+        """Test EdgeCreate with too few geometry points."""
+        with pytest.raises(ValidationError):
+            EdgeCreate(
+                start_node_id=1,
+                end_node_id=2,
+                geometry_coordinates=[
+                    Coordinate(longitude=-4.8306, latitude=39.9634),
+                ],  # Only 1 point
+                length=100.0,
+            )
+
+    @pytest.mark.unit
+    def test_edge_create_invalid_length(self):
+        """Test EdgeCreate with invalid length."""
+        with pytest.raises(ValidationError):
+            EdgeCreate(
+                start_node_id=1,
+                end_node_id=2,
+                geometry_coordinates=[
+                    Coordinate(longitude=-4.8306, latitude=39.9634),
+                    Coordinate(longitude=-4.8256, latitude=39.9598),
+                ],
+                length=0,  # Must be > 0
+            )
+
+    @pytest.mark.unit
+    def test_edge_create_invalid_speed(self):
+        """Test EdgeCreate with invalid max speed."""
+        with pytest.raises(ValidationError):
+            EdgeCreate(
+                start_node_id=1,
+                end_node_id=2,
+                geometry_coordinates=[
+                    Coordinate(longitude=-4.8306, latitude=39.9634),
+                    Coordinate(longitude=-4.8256, latitude=39.9598),
+                ],
+                length=100.0,
+                max_speed=0,  # Must be >= 1
+            )
+
+    @pytest.mark.unit
+    def test_edge_update_all_optional(self):
+        """Test EdgeUpdate with all fields optional."""
+        update = EdgeUpdate()
+        assert update.name is None
+        assert update.road_type is None
+        assert update.length is None
+
+    @pytest.mark.unit
+    def test_edge_response_from_dict(self):
+        """Test EdgeResponse creation from dictionary."""
+        from datetime import datetime
+
+        data = {
+            "id": 1,
+            "name": "Test Edge",
+            "start_node_id": 1,
+            "end_node_id": 2,
+            "road_type": RoadType.PRIMARY,
+            "geometry_coordinates": [
+                {"longitude": -4.8306, "latitude": 39.9634},
+                {"longitude": -4.8256, "latitude": 39.9598},
+            ],
+            "length": 450.0,
+            "max_speed": 50,
+            "lanes": 2,
+            "one_way": False,
+            "is_active": True,
+            "metadata_json": None,
+            "created_at": datetime.now(),
+            "updated_at": datetime.now(),
+        }
+        response = EdgeResponse(**data)
+        assert response.id == 1
+        assert response.start_node_id == 1
+        assert response.end_node_id == 2
+        assert len(response.geometry_coordinates) == 2
+
+
+# ============================================================================
+# Sample Fixtures Tests
+# ============================================================================
+
+
+class TestSampleFixtures:
+    """Tests for sample data fixtures."""
+
+    @pytest.mark.unit
+    def test_sample_nodes_count(self):
+        """Test sample nodes fixture has expected count."""
+        assert len(SAMPLE_NODES) == 6
+
+    @pytest.mark.unit
+    def test_sample_nodes_valid_schema(self):
+        """Test all sample nodes can be validated."""
+        for node_data in SAMPLE_NODES:
+            node = NodeCreate(**node_data)
+            assert node.longitude is not None
+            assert node.latitude is not None
+
+    @pytest.mark.unit
+    def test_sample_edges_count(self):
+        """Test sample edges fixture has expected count."""
+        assert len(SAMPLE_EDGES) == 4
+
+    @pytest.mark.unit
+    def test_sample_edges_valid_references(self):
+        """Test sample edges reference valid node indices."""
+        max_node_index = len(SAMPLE_NODES) - 1
+        for edge_data in SAMPLE_EDGES:
+            assert edge_data["start_node_index"] <= max_node_index
+            assert edge_data["end_node_index"] <= max_node_index
+
+    @pytest.mark.unit
+    def test_create_sample_node_data_helper(self):
+        """Test create_sample_node_data helper function."""
+        data = create_sample_node_data(
+            name="Custom Node",
+            node_type=NodeType.ROUNDABOUT.value,
+        )
+        assert data["name"] == "Custom Node"
+        assert data["node_type"] == "roundabout"
+
+    @pytest.mark.unit
+    def test_create_sample_edge_data_helper(self):
+        """Test create_sample_edge_data helper function."""
+        data = create_sample_edge_data(
+            name="Custom Edge",
+            road_type=RoadType.MOTORWAY.value,
+            max_speed=120,
+        )
+        assert data["name"] == "Custom Edge"
+        assert data["road_type"] == "motorway"
+        assert data["max_speed"] == 120


### PR DESCRIPTION
- Add Pydantic schemas for nodes and edges in the road network.
- Create SQLAlchemy models for nodes and edges with PostGIS support.
- Define enums for node types and road types.
- Establish relationships between nodes and edges in the database models.
- Document the road network data models and their usage in a new markdown file.
- Add sample data fixtures for testing road network models.
- Implement unit tests for schemas, models, and enums to ensure validation and functionality.